### PR TITLE
Fix check mode and Unsupported parameters for (systemd) module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,9 @@
     daemon_reload: true
     name: mysqld_exporter
     state: restarted
+
+- name: Ensure mysqld_exporter is enabled on boot
+  systemd:
+    daemon_reload: true
+    name: mysqld_exporter
+    enabled: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,9 +5,11 @@
     daemon_reload: true
     name: mysqld_exporter
     state: restarted
+  when: not ansible_check_mode
 
 - name: Ensure mysqld_exporter is enabled on boot
   systemd:
     daemon_reload: true
     name: mysqld_exporter
     enabled: true
+  when: not ansible_check_mode

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -70,3 +70,4 @@
   no_log: "{{ not lookup('env', 'ANSIBLE_DEBUG') | bool }}"
   notify:
     - restart mysqld exporter
+    - Ensure mysqld_exporter is enabled on boot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,3 @@
 - import_tasks: preflight.yml
 
 - import_tasks: install.yml
-
-- name: Ensure mysqld_exporter is enabled on boot
-  systemd:
-    daemon_reload: true
-    name: mysqld_exporter
-    enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,5 @@
 - name: Ensure mysqld_exporter is enabled on boot
   systemd:
     daemon_reload: true
-    started: restarted
     name: mysqld_exporter
     enabled: true


### PR DESCRIPTION
This pull request fixes two problems:

1) PR #35 introduced a bug. Playbook fails with error: "Unsupported parameters for (systemd) module: started"
2) When this role is used for the first time in a playbook in check mode, the playbook fails with error: "Could not find the requested service mysqld_exporter: host"

I took the liberty to convert the task into a handler. Because to me, that makes more sense. But if this was intended, maybe because you want that the service runs immediately, I can revert that.
