### PR TITLE
change to `state`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,6 @@
 - name: Ensure mysqld_exporter is enabled on boot
   systemd:
     daemon_reload: true
-    started: restarted
+    state: restarted
     name: mysqld_exporter
     enabled: true


### PR DESCRIPTION
Fixes error: Unsupported parameters for (systemd) module: started. Supported parameters include: daemon_reexec (daemon-reexec), state, enabled, daemon_reload (daemon-reload), name (service, unit), no_block, scope, masked, force.
